### PR TITLE
fix: use font-light for big serif text

### DIFF
--- a/components/JobGrid.js
+++ b/components/JobGrid.js
@@ -34,7 +34,7 @@ const JobGrid = ({ jobs }) => {
         className={`h-40 bg-io_${theme}-600 p-2 pt-3 text-white hover:bg-io_${theme}-700`}
       >
         <h3 className="text my-1.5 text-2xl font-medium">
-          View all <span className="font-serif">jobs</span>
+          View all <span className="font-serif font-light">jobs</span>
         </h3>
         <svg style={{ width: 24, height: 24 }} className="text-white" viewBox="0 0 24 24">
           <path

--- a/pages/index.js
+++ b/pages/index.js
@@ -36,7 +36,8 @@ export default function Home({ posts, videos, jobs, authors }) {
         <div className="pb-14 pt-24">
           <div className="container mx-auto grid grid-cols-12 gap-x-5">
             <h1 className="relative z-10 col-span-full text-4xl md:col-start-4 md:text-5xl xl:text-7xl">
-              Is technology your window of <span className="font-serif">infinite opportunity</span>?
+              Is technology your window of{' '}
+              <span className="font-serif font-light">infinite opportunity</span>?
             </h1>
             <div className="xl:-mt- col-span-full -mt-5 mb-12 flex md:col-span-10 md:-mt-6 xl:col-span-7">
               <div className="w-1/2">
@@ -92,7 +93,7 @@ export default function Home({ posts, videos, jobs, authors }) {
       </div>
 
       <SectionTitle id="articles">
-        Our latest <span className="font-serif">articles</span>
+        Our latest <span className="font-serif font-light">articles</span>
       </SectionTitle>
 
       <section className="container mx-auto">
@@ -131,12 +132,12 @@ export default function Home({ posts, videos, jobs, authors }) {
       )}
 
       <SectionTitle id="videos">
-        Our latest <span className="font-serif">videos</span>
+        Our latest <span className="font-serif font-light">videos</span>
       </SectionTitle>
       <VideoCarousel videos={videos} />
 
       <SectionTitle id="jobs">
-        Some of our <span className="font-serif">jobs</span>
+        Some of our <span className="font-serif font-light">jobs</span>
       </SectionTitle>
       <div className="container mx-auto">
         <JobGrid jobs={jobs} />

--- a/pages/podcast.js
+++ b/pages/podcast.js
@@ -16,7 +16,7 @@ export default function Podcast() {
           <div className="grid grid-cols-12">
             <div className="col-start-1 col-end-12 mb-8 md:col-end-8 md:mt-4 md:mb-10 xl:row-start-1 xl:mt-12 xl:mb-16">
               <h1 className="text-4xl md:text-5xl xl:text-7xl">
-                Soon we'll release our <span className="font-serif">podcast</span>
+                Soon we'll release our <span className="font-serif font-light">podcast</span>
               </h1>
             </div>
             <div className="col-start-1 col-end-12 mb-8 md:col-start-9 md:col-end-13 md:row-start-1 md:row-end-4 md:mb-0 xl:col-start-8 xl:row-start-1">

--- a/pages/talks.js
+++ b/pages/talks.js
@@ -25,7 +25,8 @@ export default function Talks({ talks, authors }) {
           <div className="grid grid-cols-12">
             <div className="col-start-1 col-end-12 mb-8 md:col-end-8 md:mt-4 md:mb-10 xl:row-start-1 xl:mt-12 xl:mb-16">
               <h1 className="text-4xl md:text-5xl xl:text-7xl">
-                Looking for an <span className="font-serif">inspiring talk</span> at your event?
+                Looking for an <span className="font-serif font-light">inspiring talk</span> at your
+                event?
               </h1>
             </div>
             <div className="col-start-1 col-end-12 mb-8 md:col-start-9 md:col-end-13 md:row-start-1 md:row-end-4 md:mb-0 xl:col-start-9 xl:row-start-1">

--- a/pages/videos.js
+++ b/pages/videos.js
@@ -25,7 +25,7 @@ export default function Videos({ videos }) {
             <div className="col-start-1 col-end-12 mb-8 md:col-end-8 md:mt-4 md:mb-10 xl:row-start-1 xl:mt-12 xl:mb-16">
               <h1 className="text-4xl md:text-5xl xl:text-7xl">
                 Check out our videos from{' '}
-                <span className="font-serif">meetups and expert talks</span>
+                <span className="font-serif font-light">meetups and expert talks</span>
               </h1>
             </div>
             <div className="col-start-1 col-end-12 mb-8 md:col-start-9 md:col-end-13 md:row-start-1 md:row-end-4 md:mb-0 xl:col-start-9 xl:row-start-1">


### PR DESCRIPTION
Brand guidelines state that we should use the light variant of the Reckless font. I added the `font-light` declarations where applicable.