### PR TITLE
feat(tags): use gap instead of margin

### DIFF
--- a/components/Article.js
+++ b/components/Article.js
@@ -62,7 +62,7 @@ const Article = ({ slug, date, title, tags, authors, border = true }) => {
               <time dateTime={date}>{formatDate(date)}</time>
             </dd>
           </dl>
-          <div className="mb-6 flex flex-wrap">
+          <div className="mb-6 flex flex-wrap gap-3">
             {tags.map((tag) => (
               <Tag key={tag} text={tag} />
             ))}

--- a/components/Serie.js
+++ b/components/Serie.js
@@ -60,7 +60,7 @@ const Serie = ({ slug, date, title, tags, authors, border = true, subpath = 'art
               <time dateTime={date}>{formatDate(date)}</time>
             </dd>
           </dl>
-          <div className="mb-6 flex flex-wrap">
+          <div className="mb-6 flex flex-wrap gap-3">
             {tags.map((tag) => (
               <Tag key={tag} text={tag} />
             ))}

--- a/components/Tag.js
+++ b/components/Tag.js
@@ -12,7 +12,7 @@ const Tag = ({ text }) => {
   return (
     <Link href={`/tags/${kebabCase(text)}`}>
       <a
-        className={`mr-3 bg-io_${theme}-600 px-1 text-sm font-medium uppercase text-white hover:bg-white hover:text-io_${theme}-600`}
+        className={`bg-io_${theme}-600 px-1 text-sm font-medium uppercase text-white hover:bg-white hover:text-io_${theme}-600`}
       >
         {text.split(' ').join('-')}
       </a>

--- a/components/Talk.js
+++ b/components/Talk.js
@@ -47,10 +47,10 @@ const Talk = ({ title, summary, authors, tags, video, slides }) => {
               </div>
             ))}
 
-          <div className="mb-3 flex flex-nowrap gap-1 line-clamp-1">
+          <div className="mb-3 flex flex-wrap gap-3">
             {tags.length > 0 &&
               tags.map((tag) => (
-                <div key={tag} className="inline-block">
+                <div key={tag} className="inline-block whitespace-nowrap">
                   <Tag key={tag} text={tag} />
                 </div>
               ))}

--- a/layouts/PostLayout.js
+++ b/layouts/PostLayout.js
@@ -175,7 +175,7 @@ export default function PostLayout({ frontMatter, authorDetails, serie, next, pr
                   <h2 className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
                     Tags
                   </h2>
-                  <div className="mt-2 flex flex-wrap">
+                  <div className="mt-2 flex flex-wrap gap-3">
                     {tags.map((tag) => (
                       <Tag key={tag} text={tag} />
                     ))}

--- a/layouts/SerieLayout.js
+++ b/layouts/SerieLayout.js
@@ -183,7 +183,7 @@ export default function PostLayout({ frontMatter, authorDetails, posts, next, pr
                   <h2 className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
                     Tags
                   </h2>
-                  <div className="mt-2 flex flex-wrap">
+                  <div className="mt-2 flex flex-wrap gap-3">
                     {tags.map((tag) => (
                       <Tag key={tag} text={tag} />
                     ))}


### PR DESCRIPTION
Use gap instead of margin to also have vertical spacing.

Before:

![Screenshot 2022-12-05 at 10 07 08](https://user-images.githubusercontent.com/14149640/205597907-41af6343-bfd7-40cd-b242-6c4cbfa16757.png)

After:

![Screenshot 2022-12-05 at 10 07 14](https://user-images.githubusercontent.com/14149640/205597937-1402a280-72fc-46c4-9e89-f1bc2af7dc81.png)

