### PR TITLE
Feature/articles preview

### DIFF
--- a/components/Article.js
+++ b/components/Article.js
@@ -3,7 +3,6 @@ import Image from '@/components/Image'
 import Link from '@/components/Link'
 import formatDate from '@/lib/utils/formatDate'
 import Tag from '@/components/Tag'
-import Arrow from '@/data/arrow.svg'
 import { useBrandingTheme } from '@/lib/hooks/useBrandingTheme'
 
 const Article = ({ slug, date, title, summary, tags, authors, border = true }) => {
@@ -72,9 +71,6 @@ const Article = ({ slug, date, title, summary, tags, authors, border = true }) =
               <Tag key={tag} text={tag} />
             ))}
           </div>
-          <Link href={`/articles/${slug}`}>
-            <Arrow className="w-6" />
-          </Link>
         </div>
       </div>
     </article>

--- a/components/Article.js
+++ b/components/Article.js
@@ -6,7 +6,7 @@ import Tag from '@/components/Tag'
 import Arrow from '@/data/arrow.svg'
 import { useBrandingTheme } from '@/lib/hooks/useBrandingTheme'
 
-const Article = ({ slug, date, title, tags, authors, border = true }) => {
+const Article = ({ slug, date, title, summary, tags, authors, border = true }) => {
   const { theme } = useBrandingTheme()
 
   return (
@@ -54,7 +54,12 @@ const Article = ({ slug, date, title, tags, authors, border = true }) => {
         )}
         <div className={`col-span-full ${authors ? 'md:col-start-4 xl:col-start-7' : ''}`}>
           <Link href={`/articles/${slug}`}>
-            <h2 className="teaser-title text-2xl">{<MarkdownRenderer markdown={title} />}</h2>
+            <h2 className="teaser-title mb-2 text-3xl">{<MarkdownRenderer markdown={title} />}</h2>
+            <div className="mb-3 hidden md:block">
+              <h3 className="hyphens-auto line-clamp-3">
+                {<MarkdownRenderer markdown={summary} />}
+              </h3>
+            </div>
           </Link>
           <dl className="mb-4">
             <dt className="sr-only">Published on</dt>

--- a/data/blog/benefits-of-functional-programming.md
+++ b/data/blog/benefits-of-functional-programming.md
@@ -3,10 +3,7 @@ title: 'Benefits of functional programming'
 date: '2022-12-27'
 tags: ['frontend', 'functional programming', 'javascript']
 images: ['/articles/benefits-of-functional-programming/pexels-pixabay-270557.jpg']
-summary: [
-    'Writing code in a functional way can help to solve complex problems in a efficient and in a reusable manner,
-    for creating clean and maintainable software.',
-  ]
+summary: 'Writing code in a functional way can help to solve complex problems in a efficient and in a reusable manner, for creating clean and maintainable software.'
 authors: ['ravindre-ramjiawan']
 theme: 'blue'
 ---

--- a/layouts/AuthorLayout.js
+++ b/layouts/AuthorLayout.js
@@ -87,7 +87,7 @@ export default function AuthorLayout({ children, frontMatter, posts, talks }) {
           </SectionTitle>
           <section className="container mx-auto max-w-2xl">
             {posts.map((fm, index) => {
-              const { slug, date, title, tags } = fm
+              const { slug, date, title, summary, tags } = fm
 
               return (
                 <Article
@@ -95,6 +95,7 @@ export default function AuthorLayout({ children, frontMatter, posts, talks }) {
                   slug={slug}
                   date={date}
                   title={title}
+                  summary={summary}
                   tags={tags}
                   border={index !== 0}
                 />

--- a/layouts/AuthorLayout.js
+++ b/layouts/AuthorLayout.js
@@ -26,6 +26,7 @@ export default function AuthorLayout({ children, frontMatter, posts, talks }) {
                 height={800}
                 layout="responsive"
                 className="rounded-full"
+                alt="avatar"
               />
             </div>
 

--- a/layouts/ListLayout.js
+++ b/layouts/ListLayout.js
@@ -71,7 +71,7 @@ export default function ListLayout({
         <ul>
           {!filteredBlogPosts.length && 'No articles found.'}
           {displayPosts.map((frontMatter, index) => {
-            const { slug, date, title, tags } = frontMatter
+            const { slug, date, title, summary, tags } = frontMatter
             const authorsResolved = frontMatter.authors.map((author) => {
               return authors[author]
             })
@@ -83,6 +83,7 @@ export default function ListLayout({
                   slug={slug}
                   date={date}
                   title={title}
+                  summary={summary}
                   tags={tags}
                   authors={authorsResolved}
                   border={index !== 0}

--- a/pages/index.js
+++ b/pages/index.js
@@ -116,7 +116,7 @@ export default function Home({ posts, videos, jobs, contributors }) {
       <section className="container mx-auto">
         {!posts.length && 'No articles found.'}
         {posts.slice(0, MAX_BLOG_POSTS).map((frontMatter, index) => {
-          const { slug, date, title, tags } = frontMatter
+          const { slug, date, title, summary, tags } = frontMatter
           const authorsResolved = frontMatter.authors.map((author) => {
             return authors[author]
           })
@@ -127,6 +127,7 @@ export default function Home({ posts, videos, jobs, contributors }) {
               slug={slug}
               date={date}
               title={title}
+              summary={summary}
               tags={tags}
               authors={authorsResolved}
               border={index !== 0}

--- a/pages/videos.js
+++ b/pages/videos.js
@@ -4,7 +4,6 @@ import { getAllVideos } from '@/lib/youtube'
 import VideoCard from '@/components/VideoCard'
 import Image from '@/components/Image'
 import { useBrandingTheme } from '@/lib/hooks/useBrandingTheme'
-import SocialIcon from '@/components/social-icons'
 
 export async function getStaticProps() {
   const { videos } = await getAllVideos()

--- a/pages/videos.js
+++ b/pages/videos.js
@@ -35,6 +35,7 @@ export default function Videos({ videos }) {
                 height={1192}
                 layout="responsive"
                 className="rounded-full"
+                alt="meetup"
               />
             </div>
             <div className="col-span-full md:col-span-5 md:col-start-4 xl:col-span-4 xl:col-start-4">


### PR DESCRIPTION
Show Articles preview in all articles lists. Key features:

- The preview is limited to 3 lines of text. 
- The header and summary styles of Articles are consistent with the header and summary styles of Talks
- The link at the bottom of each article is removed in order to reduce clutter on the page. Besides that, the header and summary of each article is the link itself.

Screenshot of how the articles list looked before:
![articles-before](https://github.com/iodigital-com/io-technology/assets/11290624/61b6511e-0e62-455a-a5b3-9c7a56c72261)

And how it looks after:
![articles-after](https://github.com/iodigital-com/io-technology/assets/11290624/e91f06b4-df60-4e98-a36e-24f2c5fd55fb)
