### PR TITLE
fix: make mobile nav clickable by forcing pointer-events

### DIFF
--- a/components/LayoutWrapper.js
+++ b/components/LayoutWrapper.js
@@ -17,6 +17,7 @@ const LayoutWrapper = ({ children }) => {
     const headerHeight = headerRef.current.scrollHeight
     const handleScroll = () => {
       const hasScrolledPasHeader = window.scrollY >= headerHeight
+
       setScrolledPassedHeader(hasScrolledPasHeader)
 
       if (!hasScrolledPasHeader) {
@@ -39,7 +40,7 @@ const LayoutWrapper = ({ children }) => {
         ref={headerRef}
         className={`sticky top-0 z-50 duration-150 ease-out ${
           scrolledPassedHeader ? 'pointer-events-none' : `bg-io_${themeBg}-500`
-        } py-4 px-4 xl:bg-io_${themeBg}-500`}
+        } px-4 py-4 xl:bg-io_${themeBg}-500`}
       >
         <div className="container mx-auto flex items-center justify-between p-0">
           <div>
@@ -66,7 +67,10 @@ const LayoutWrapper = ({ children }) => {
               </div>
             </Link>
           </div>
-          <div className="relative flex items-center text-base leading-5" ref={navigationItemsRef}>
+          <div
+            className={`relative flex items-center text-base leading-5`}
+            ref={navigationItemsRef}
+          >
             <div
               className={`hidden items-center rounded-full pl-2 sm:flex sm:pr-12 ${
                 navigationIsOpen ? 'pointer-events-auto border-white' : 'border-gray-200'
@@ -120,7 +124,7 @@ const LayoutWrapper = ({ children }) => {
                 </svg>
               </button>
               <span
-                className={`absolute top-0 right-0 bottom-0 -z-10 h-16 w-full rounded-full border border-gray-200 bg-white transition-all duration-300 ease-out ${
+                className={`absolute bottom-0 right-0 top-0 -z-10 h-16 w-full rounded-full border border-gray-200 bg-white transition-all duration-300 ease-out ${
                   navigationIsOpen ? `max-w-2xl` : 'max-w-[calc(72px)]'
                 }
                 ${scrolledPassedHeader ? 'sm:opacity-100' : 'opacity-0'}`}

--- a/components/MobileNav.js
+++ b/components/MobileNav.js
@@ -18,10 +18,10 @@ const MobileNav = () => {
   }
 
   return (
-    <div className="sm:hidden">
+    <div className="pointer-events-auto sm:hidden">
       <button
         type="button"
-        className="pointer-events-auto h-16 w-16 rounded-full border border-gray-100 bg-white p-5"
+        className=" h-16 w-16 rounded-full border border-gray-100 bg-white p-5"
         aria-label="Toggle Menu"
         onClick={onToggleNav}
       >
@@ -37,7 +37,7 @@ const MobileNav = () => {
         </svg>
       </button>
       <div
-        className={`fixed top-0 right-0 z-10 flex h-full w-full transform flex-col items-end bg-white pt-10 duration-300 ease-in-out ${
+        className={`fixed right-0 top-0 z-10 flex h-full w-full transform flex-col items-end bg-white pt-10 duration-300 ease-in-out ${
           navShow ? 'translate-x-0' : '-translate-x-full'
         }`}
       >

--- a/components/MobileNav.js
+++ b/components/MobileNav.js
@@ -21,7 +21,7 @@ const MobileNav = () => {
     <div className="pointer-events-auto sm:hidden">
       <button
         type="button"
-        className=" h-16 w-16 rounded-full border border-gray-100 bg-white p-5"
+        className="h-16 w-16 rounded-full border border-gray-100 bg-white p-5"
         aria-label="Toggle Menu"
         onClick={onToggleNav}
       >


### PR DESCRIPTION
# Context
Previously some changes have been made to make everything behind the transparent mobile header clickable when you scroll. By doing so the mobile nav was affected and you couldn't click on items after scrolling on the page (https://github.com/clarkeverdel/io-technology/commit/33bf8d7134c3320d98bc3d043318bd7bdfd60789). 

# Changes
Pointer events are now forced on the mobile nav wrapper div.

# Reproduction

1. Go to an article
2. Scroll on the page
3. Open mobile nav
4. Click on a navigation item link

**Current behavior:** When you click on the link, your pointer reacts to the content behind the mobile nav.
**Expected:** The link should work and navigate you to the page.