### PR TITLE
fix: update deprecated GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -18,13 +18,13 @@ jobs:
 
     steps:
       - name: Checkout current repository to Master branch
-        uses: actions/checkout@v2
-      - name: Setup NodeJs 20.x
-        uses: actions/setup-node@v1
+        uses: actions/checkout@v4
+      - name: Setup NodeJs 22.x
+        uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '22.x'
       - name: Cache dependencies and build outputs to improve workflow execution time.
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: node_modules
           key: ${{ runner.os }}-js-${{ hashFiles('package-lock.json') }}


### PR DESCRIPTION
- Update actions/checkout from v2 to v4
- Update actions/setup-node from v1 to v4
- Update actions/cache from v1 to v4
- Update Node.js version from 20.x to 22.x to match project requirements