### PR TITLE
feat(Post Layout): restyle header text and image based on iodigital blog (delete this merge request)

### DIFF
--- a/layouts/PostLayout.tsx
+++ b/layouts/PostLayout.tsx
@@ -45,6 +45,8 @@ export default function PostLayout({
   const { theme } = useBrandingTheme()
   const authorNames = new Intl.ListFormat('en').format(authorDetails.map(({ name }) => name))
 
+  const hasHeroImage = images && images.length > 0
+
   return (
     <>
       <BlogSEO
@@ -56,15 +58,31 @@ export default function PostLayout({
       <ScrollTop />
       <article>
         <div
-          className={`bg-io_${theme}-500 pb-14 pt-24 ${
-            images && images.length > 0 ? 'mb-72' : 'mb-12'
+          className={`relative overflow-hidden pb-14 pt-32 md:pt-52 lg:pt-96 mb-12 ${
+            hasHeroImage ? '' : `bg-io_${theme}-500`
           }`}
         >
-          <div className="container mx-auto">
-            <h1 className="heading-title text-4xl font-medium xl:text-7xl">
+          {hasHeroImage && (
+            <>
+              <Image
+                src={images[0] || ''}
+                alt={title}
+                fill
+                priority={true}
+                className="object-cover"
+              />
+              <div className={`absolute inset-0 backdrop-blur-md bg-black/70`} aria-hidden="true" />
+            </>
+          )}
+          <div className={`relative container mx-auto`}>
+            <h1
+              className={`heading-title text-4xl font-medium xl:text-7xl ${
+                hasHeroImage ? 'text-white' : ''
+              }`}
+            >
               {<MarkdownRenderer markdown={title} />}
             </h1>
-            <div className="my-4 divide-x">
+            <div className={`my-4 divide-x ${hasHeroImage ? 'text-white' : ''}`}>
               <p className="inline pr-2 text-xl font-light">By {authorNames}</p>
               <time className="inline px-2 font-light" dateTime={date || ''}>
                 {formatDate(date || '')}
@@ -75,23 +93,14 @@ export default function PostLayout({
               </p>
             </div>
             <div className="grid grid-cols-4">
-              <p className="col-span-full col-start-1 text-2xl md:col-start-2 xl:col-start-3">
+              <p
+                className={`col-span-full col-start-1 text-2xl md:col-start-2 xl:col-start-3 ${
+                  hasHeroImage ? 'text-white' : ''
+                }`}
+              >
                 {summary}
               </p>
             </div>
-
-            {images && images.length > 0 && (
-              <div className="-mt-20 translate-y-32 md:-mt-64 md:translate-y-72">
-                <Image
-                  src={images[0] || ''}
-                  alt={title}
-                  width={1280}
-                  height={720}
-                  priority={true}
-                  className="h-auto w-full object-cover"
-                />
-              </div>
-            )}
           </div>
         </div>
 

--- a/layouts/PostLayout.tsx
+++ b/layouts/PostLayout.tsx
@@ -71,7 +71,7 @@ export default function PostLayout({
                 priority={true}
                 className="object-cover"
               />
-              <div className={`absolute inset-0 backdrop-blur-md bg-black/70`} aria-hidden="true" />
+              <div className="absolute inset-0 animate-overlay-in" aria-hidden="true" />
             </>
           )}
           <div className={`relative container mx-auto`}>

--- a/pages/articles/[...slug].tsx
+++ b/pages/articles/[...slug].tsx
@@ -56,9 +56,20 @@ export async function getStaticProps({ params }: { params: { slug: string[] } })
   const { events } = await getLatestEvents(3)
 
   const theme = post.frontMatter.theme || 'blue'
+  const transparentHeader = !!(post.frontMatter.images && post.frontMatter.images.length > 0)
 
   return {
-    props: { post, authorDetails, prev, next, jobs, events, serie, theme },
+    props: {
+      post,
+      authorDetails,
+      prev,
+      next,
+      jobs,
+      events,
+      serie,
+      theme,
+      transparentHeader,
+    },
   }
 }
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -24,6 +24,15 @@ module.exports = {
       padding: '1rem',
     },
     extend: {
+      keyframes: {
+        'overlay-in': {
+          '0%': { backdropFilter: 'blur(0)', backgroundColor: 'transparent' },
+          '100%': { backdropFilter: 'blur(12px)', backgroundColor: 'rgb(0 0 0 / 0.7)' },
+        },
+      },
+      animation: {
+        'overlay-in': 'overlay-in 1.5s ease-out 0.6s both',
+      },
       spacing: {
         '9/16': '56.25%',
       },


### PR DESCRIPTION
The image is darkened and blurred gradually on load to keep the text accessible.

1. Here's how it looks with a dark background image:

<img width="2074" height="1340" alt="post-1" src="https://github.com/user-attachments/assets/5cdbae9d-906e-4c5a-a4b2-1782b29044e1" />

2. And with a bright image:

<img width="2074" height="1340" alt="post-2" src="https://github.com/user-attachments/assets/67c5771a-efe5-4771-93b1-c81465f225af" />