### PR TITLE
fix(Series Layout): show proper series images (2nd attempt)

### DIFF
--- a/layouts/SerieLayout.tsx
+++ b/layouts/SerieLayout.tsx
@@ -189,7 +189,7 @@ export default function PostLayout({
                 <ul>
                   {!posts.length && 'No articles found.'}
                   {posts.map((frontMatter, index) => {
-                    const { slug, date, title, tags } = frontMatter
+                    const { slug, date, title, tags, images } = frontMatter
 
                     return (
                       <li key={slug}>
@@ -203,6 +203,7 @@ export default function PostLayout({
                           border={index !== 0}
                           type="article"
                           showAuthors={false}
+                          {...(images && { images })}
                         />
                       </li>
                     )

--- a/layouts/SeriesLayout.tsx
+++ b/layouts/SeriesLayout.tsx
@@ -24,7 +24,7 @@ export default function ListLayout({
         <ul>
           {!series.length && 'No series found.'}
           {series.map((frontMatter, index) => {
-            const { slug, date, title, tags } = frontMatter
+            const { slug, date, title, tags, images } = frontMatter
             const authorsResolved = frontMatter.authors
               .map((author) => {
                 return authors[author]
@@ -46,6 +46,7 @@ export default function ListLayout({
                   border={index !== 0}
                   type="serie"
                   basePath={`/${subpath}`}
+                  {...(images && { images })}
                 />
               </li>
             )


### PR DESCRIPTION
Pages on which this fix is applied:
1. https://techhub.iodigital.com/series
2. Specific series pages, for example: https://techhub.iodigital.com/series/how-do-i-build-a-component-library

<img width="763" height="500" alt="series-fix" src="https://github.com/user-attachments/assets/f8abaf31-829e-47b1-9db4-5d9ee6c9a8ca" />
