### PR TITLE
fix(code elements): improve contrast ratio for better accessibilty

### DIFF
--- a/css/prism-vs-code-dark-modern-theme.css
+++ b/css/prism-vs-code-dark-modern-theme.css
@@ -1,0 +1,162 @@
+/* VS Code default "Dark Modern" Theme for PrismJS */
+/* It was created with https://prism.dotenv.dev/ and VS Code default dark theme */
+
+code[class*='language-'],
+pre[class*='language-'] {
+  color: #cccccc;
+  font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+  text-align: left;
+  white-space: pre;
+  word-spacing: normal;
+  word-break: normal;
+  word-wrap: normal;
+  line-height: 1.5;
+
+  -moz-tab-size: 4;
+  -o-tab-size: 4;
+  tab-size: 4;
+
+  -webkit-hyphens: none;
+  -moz-hyphens: none;
+  -ms-hyphens: none;
+  hyphens: none;
+}
+
+pre[class*='language-']::-moz-selection,
+pre[class*='language-'] ::-moz-selection,
+code[class*='language-']::-moz-selection,
+code[class*='language-'] ::-moz-selection {
+  text-shadow: none;
+  background: none;
+}
+
+pre[class*='language-']::selection,
+pre[class*='language-'] ::selection,
+code[class*='language-']::selection,
+code[class*='language-'] ::selection {
+  text-shadow: none;
+  background: none;
+}
+
+@media print {
+  code[class*='language-'],
+  pre[class*='language-'] {
+    text-shadow: none;
+  }
+}
+
+/* Code blocks */
+pre[class*='language-'] {
+  padding: 1em;
+  margin: 0.5em 0;
+  overflow: auto;
+}
+
+:not(pre) > code[class*='language-'],
+pre[class*='language-'] {
+  color: white;
+  background: #1f1f1f;
+}
+
+:not(pre) > code[class*='language-'] {
+  padding: 0.1em;
+  border-radius: 0.3em;
+  white-space: normal;
+}
+
+.token.variable {
+  color: #d4d4d4;
+}
+
+.token.operator {
+  color: #d4d4d4;
+}
+
+.token.prolog {
+  color: #000080;
+}
+
+.token.comment {
+  color: #6a9955;
+}
+
+.token.punctuation {
+  color: #6a9955;
+}
+
+.token.builtin {
+  color: #4fc1ff;
+}
+
+.token.number {
+  color: #b5cea8;
+}
+
+.token.inserted {
+  color: #b5cea8;
+}
+
+.token.constant {
+  color: #646695;
+}
+
+.token.hexcode {
+  color: #646695;
+}
+
+.token.tag {
+  color: #569cd6;
+}
+
+.token.changed {
+  color: #569cd6;
+}
+
+.token.function {
+  color: #569cd6;
+}
+
+.token.keyword {
+  color: #569cd6;
+}
+
+.token.attr-name {
+  color: #9cdcfe;
+}
+
+.token.selector {
+  color: #9cdcfe;
+}
+
+.token.property {
+  color: #9cdcfe;
+}
+
+.token.deleted {
+  color: #ce9178;
+}
+
+.token.string {
+  color: #ce9178;
+}
+
+.token.regex {
+  color: #d16969;
+}
+
+.token.char {
+  color: #d16969;
+}
+
+.token.class-name {
+  color: #4ec9b0;
+}
+
+.token.important,
+.token.bold {
+  font-weight: bold;
+}
+
+.token.italic {
+  font-style: italic;
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,5 +1,6 @@
 import '@/css/tailwind.css'
 import '@/css/prism.css'
+import '@/css/prism-vs-code-dark-modern-theme.css'
 import '@/css/font.css'
 import '@/css/post-layout.css'
 import '@/css/images.css'

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -44,6 +44,7 @@ module.exports = {
         primary: brandColors.colors.io_blue,
         gray: colors.neutral,
         ...brandColors.colors,
+        'code-pink': '#D41675',
       },
       typography: (theme) => ({
         DEFAULT: {
@@ -77,7 +78,7 @@ module.exports = {
               backgroundColor: theme('colors.gray.800'),
             },
             code: {
-              color: theme('colors.pink.500'),
+              color: theme('colors.code-pink'),
               backgroundColor: theme('colors.gray.100'),
               paddingLeft: '4px',
               paddingRight: '4px',


### PR DESCRIPTION
Changes:
- improve contrast ratio for pink text color within small ```<code>``` elements to make it pass "WCAG AA" score

<img width="1029" height="663" alt="old-vs-new-pink-color-contrast" src="https://github.com/user-attachments/assets/d1592d0f-4532-4c0e-815e-d446cc422ff5" />

<img width="1401" height="824" alt="old-vs-new-pink-color-comparison" src="https://github.com/user-attachments/assets/c124c863-9251-44ad-8554-84e73b2dc568" />

- improve contrast ratio for large ```<code>``` elements by replacing color theme with default VS Code "Dark Modern" theme. The current version of the color theme for large ```<code>``` elements doesn't have enough contrast between the background and text colors. So I copied the default dark theme from VS Code, then converted it to CSS and imported it into tech_hub.

<img width="1328" height="986" alt="old-vs-new-code-theme-comparison" src="https://github.com/user-attachments/assets/c7159a3b-1b44-428a-9716-c347ec2ffd64" />

Here's what the final Lighthouse audit score would look like after those changes:

<img width="1538" height="918" alt="old-vs-new-audit" src="https://github.com/user-attachments/assets/bd1f2d72-d7ff-450b-abde-714c19e6bee7" />
