### PR TITLE
feat(PostLayout, SerieLayout): adjust titles placement for XL-screen width to fit more content

### DIFF
--- a/layouts/PostLayout.tsx
+++ b/layouts/PostLayout.tsx
@@ -64,17 +64,18 @@ export default function PostLayout({
             <h1 className="heading-title text-4xl font-medium xl:text-7xl">
               {<MarkdownRenderer markdown={title} />}
             </h1>
-            <div className="my-4 divide-x">
-              <p className="inline pr-2 text-xl font-light">By {authorNames}</p>
-              <time className="inline px-2 font-light" dateTime={date || ''}>
-                {formatDate(date || '')}
-              </time>
-              <p className="inline pl-2 font-light">
-                <Clock className="mr-2 inline w-4" />
-                {readingTime?.text || ''}
-              </p>
-            </div>
-            <div className="grid grid-cols-4">
+
+            <div className="grid grid-cols-4 mt-4 xl:mt-8">
+              <div className="mb-4 divide-x col-span-full xl:col-span-2">
+                <p className="inline pr-2 text-xl font-light">By {authorNames}</p>
+                <time className="inline px-2 font-light" dateTime={date || ''}>
+                  {formatDate(date || '')}
+                </time>
+                <p className="inline pl-2 font-light">
+                  <Clock className="mr-2 inline w-4" />
+                  {readingTime?.text || ''}
+                </p>
+              </div>
               <p className="col-span-full col-start-1 text-2xl md:col-start-2 xl:col-start-3">
                 {summary}
               </p>

--- a/layouts/SerieLayout.tsx
+++ b/layouts/SerieLayout.tsx
@@ -60,17 +60,18 @@ export default function PostLayout({
             <h1 className="heading-title text-4xl font-medium xl:text-7xl">
               {<MarkdownRenderer markdown={title} />}
             </h1>
-            <div className="my-4 divide-x">
-              <p className="inline pr-2 text-xl font-light">By {authorNames}</p>
-              <time className="inline px-2 font-light" dateTime={date || ''}>
-                {formatDate(date || '')}
-              </time>
-              <p className="inline pl-2 font-light">
-                <Clock className="mr-2 inline w-4" />
-                {readingTime?.text || ''}
-              </p>
-            </div>
-            <div className="grid grid-cols-4">
+
+            <div className="grid grid-cols-4 mt-4 xl:mt-8">
+              <div className="mb-4 divide-x col-span-full xl:col-span-2">
+                <p className="inline pr-2 text-xl font-light">By {authorNames}</p>
+                <time className="inline px-2 font-light" dateTime={date || ''}>
+                  {formatDate(date || '')}
+                </time>
+                <p className="inline pl-2 font-light">
+                  <Clock className="mr-2 inline w-4" />
+                  {readingTime?.text || ''}
+                </p>
+              </div>
               <p className="col-span-full col-start-1 text-2xl md:col-start-2 xl:col-start-3">
                 {summary}
               </p>


### PR DESCRIPTION
Adjust article description placement. It will be placed in columns: 1st column for metadata and the 2nd column for article description. And it's only applied to XL screen width (wide desktop screens) to fit more content.

<img width="1883" height="809" alt="adjusted-article-description-placement" src="https://github.com/user-attachments/assets/7e0b79ae-5777-4f33-9ced-8d4df59aed01" />
